### PR TITLE
Makes slashes used for escaping brackets not display

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -388,6 +388,8 @@ function updateRender() {
 
         } else {
             output += tok
+                .replace(/\\\[/g, '[')
+                .replace(/\\\]/g, ']')
                 .replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')
                 .replace(/>/g, '&gt;')


### PR DESCRIPTION
Love you and what you made :purple_heart:
So nice not opening SS14 to edit things

This is a step closer to parity with SS14, which (as far as I can remember) hides slashes for escaped brackets. I haven't considered edge cases
<img width="949" height="188" alt="image" src="https://github.com/user-attachments/assets/9c97bd42-906e-45f4-9788-7a769551e40e" />